### PR TITLE
turn off TextEditing when focus is out.

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -740,7 +740,7 @@ RubAbstractTextArea >> editPrimarySelectionSeparately [
 { #category : #accessing }
 RubAbstractTextArea >> editing [
 
-	^ editing
+	^ editing = true
 ]
 
 { #category : #'accessing editing mode' }
@@ -1079,7 +1079,11 @@ RubAbstractTextArea >> hasFocus [
 
 { #category : #'accessing editing state' }
 RubAbstractTextArea >> hasFocus: aBoolean [
-	^ self editingState hasFocus: aBoolean 
+
+	(aBoolean ~= self hasFocus and: [ editing = true ]) ifTrue: [ 
+		self editor unselect.
+		editing := false ].
+	^ self editingState hasFocus: aBoolean
 ]
 
 { #category : #'accessing selection' }


### PR DESCRIPTION
This PR enables us to change focus while typing in the IME. If a focus is moved out  when choosing in IME list, the current choice is considered the final decision and inserted into the text content.
I think this branch is now functional enough to be tested by wider audiences.